### PR TITLE
Stickler

### DIFF
--- a/bash_functions
+++ b/bash_functions
@@ -357,5 +357,5 @@ seal_to_loader() {
     predict_future_pcrs "$workdir" --substitute-bsa-unix-path "$(efi_path_to_unix "$current_loader")=$loader"
     seal_data "$workdir" <$LUKS_KEY
     mkdir -p $(emboot_state_path "$krel")
-    cp -f "$workdir"/counter "$workdir"/sealed.pub "$workdir"/sealed.priv "$(emboot_state_path "$krel")/"
+    cp -f "$workdir"/pcrs "$workdir"/counter "$workdir"/sealed.pub "$workdir"/sealed.priv "$(emboot_state_path "$krel")/"
 }

--- a/functions
+++ b/functions
@@ -41,8 +41,8 @@ read_counter() {
     tpm2_nvread -C o "$COUNTER_HANDLE" -s 8
 }
 
-next_counter() {
-    printf '%016x' "$((1 + 0x$(read_counter | $XXD -p)))" | $XXD -r -p
+read_pcrs() {
+    tpm2_pcrread -Q sha256:"$SEAL_PCRS" -o "$1"
 }
 
 create_provision_context() {
@@ -81,13 +81,13 @@ create_efi_app() {
 predict_future_pcrs() {
     workdir=${1:-.}
     shift
-    tpm_futurepcr -L "$SEAL_PCRS" -H sha256 "$@" -o "$workdir"/future_pcrs -v
+    tpm_futurepcr -L "$SEAL_PCRS" -H sha256 "$@" -o "$workdir"/pcrs -v
 }
 
 seal_data() {
     workdir=${1:-.}
     tpm2_startauthsession -S "$workdir"/session.ctx
-    tpm2_policypcr -S "$workdir"/session.ctx -l sha256:"$SEAL_PCRS" -f "$workdir"/future_pcrs
+    tpm2_policypcr -S "$workdir"/session.ctx -l sha256:"$SEAL_PCRS" -f "$workdir"/pcrs
     tpm2_policynv -S "$workdir"/session.ctx -C o -i "$workdir"/counter -L "$workdir"/policy "$COUNTER_HANDLE" ule
     tpm2_create -C "$workdir"/provision.ctx -g sha256 -a 'fixedtpm|fixedparent|adminwithpolicy|noda' -i - \
         -L "$workdir"/policy -r "$workdir"/sealed.priv -u "$workdir"/sealed.pub
@@ -97,10 +97,16 @@ seal_data() {
 
 unseal_data() {
     workdir=${1:-.}
+    if [ ! -r "$workdir"/pcrs ]; then
+        read_pcrs "$workdir"/pcrs
+    fi
+    if [ ! -r "$workdir"/counter ]; then
+        read_counter >"$workdir"/counter
+    fi
     tpm2_load -Q -C "$workdir"/provision.ctx \
             -r "$workdir"/sealed.priv -u "$workdir"/sealed.pub -c "$workdir"/load.ctx && \
         tpm2_startauthsession -Q -S "$workdir"/session.ctx --policy-session && \
-        tpm2_policypcr -Q -S "$workdir"/session.ctx -l sha256:"$SEAL_PCRS" && \
+        tpm2_policypcr -Q -S "$workdir"/session.ctx -l sha256:"$SEAL_PCRS" -f "$workdir"/pcrs && \
         tpm2_policynv -Q -C o -S "$workdir"/session.ctx -i "$workdir"/counter "$COUNTER_HANDLE" ule && \
         tpm2_unseal -Q -c "$workdir"/load.ctx -p session:"$workdir"/session.ctx
     rc=$?

--- a/initramfs-hooks/efi-measured-boot
+++ b/initramfs-hooks/efi-measured-boot
@@ -14,7 +14,7 @@ esac
 
 . /usr/share/initramfs-tools/hook-functions
 
-for i in createprimary load startauthsession policypcr policynv unseal flushcontext; do
+for i in createprimary flushcontext load pcrread policynv policypcr startauthsession unseal; do
     copy_exec /usr/bin/tpm2_$i /usr/bin
 done
 copy_exec /usr/lib/x86_64-linux-gnu/libtss2-tcti-device.so.0 /usr/lib/x86_64-linux-gnu


### PR DESCRIPTION
 * Store the pcrs (alongside the counter) when sealing because I am
   pedantic and want to test the correct policy rather than accepting a
   policy mismatch on an altered boot chain.

 * But also pull the current counter or pcr values if they happen not to
   be in the emboot directory for a given krel.

 * Use the tmpdir helper functionality in emboot_unseal.sh rather than a
   fixed directory name.